### PR TITLE
깃 허브 액션 트리거 중 브랜치 조건 설정 작업

### DIFF
--- a/.github/workflows/github-action-demo.yaml
+++ b/.github/workflows/github-action-demo.yaml
@@ -1,6 +1,9 @@
 name: GitHub Actions Demo
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
-on: [push]
+on: 
+  push:
+    branches:
+      - main
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@
 
 - Triggerd 된 브랜치를 체크아웃 받고 있음.
 - 테스트 브랜치: test/workflow-ex2
+
+### Triggerd 조건에서 push 일 때 특정 브랜치일때만 Trigger가 가능할까?
+
+```
+on: 
+  push:
+    branches:
+      - main
+```
+위의 설정을 통해 특정 브랜치에만 트리거 조건을 걸 수 있음.


### PR DESCRIPTION
현재는 어떤 브랜치 상관없이 푸시되는 순간 깃 허브 액션이 활성화되고 있어서, 특정 브랜치일때만 깃 허브 액션이 작동되도록 구현